### PR TITLE
revise the plugin structure and simplify some filtering

### DIFF
--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -41,9 +41,6 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 		'exclude'    => '',
 	);
 
-	// Filter the defaults
-	$defaults = apply_filters( 'vpm_gallery_defaults', $defaults );
-
 	// Parse the args
 	$args = shortcode_atts( $defaults, $attr );
 

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -36,7 +36,7 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 		'icontag'    => 'dt',
 		'captiontag' => 'dd',
 		'columns'    => 2,
-		'size'       => isset( $attr['size'] ) ? $attr['size'] : 'thumbnail', // defaults to thumbnail size
+		'size'       => 'thumbnail', // defaults to thumbnail size
 		'include'    => '',
 		'exclude'    => '',
 	);
@@ -79,9 +79,9 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 
 	// Define layout args
 	$selector   = "gallery-{$instance}"; // unique selector for CSS
-	$columns    = isset( $attr['columns'] ) ? intval( $attr['columns'] ) : 3; // default to 3 columns if not set
+	$columns    = $args['columns']; // default to 3 columns if not set
 	$item_width = $columns > 0 ? floor( 100 / $columns ) : 100;
-	$size_class = sanitize_html_class( isset( $attr['size'] ) ? $attr['size'] : 'thumbnail' ); // for CSS purposes
+	$size_class = sanitize_html_class( $args['size'] ); // for CSS purposes
 
 	// Gallery output
 	$inner_html = '';
@@ -92,7 +92,7 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 
 		// Fetch full url, make cropped URL
 		$img_full = wp_get_attachment_image_src( $id, 'full' );
-		$src_full = apply_filters( 'vpm_gallery_image_src_full', $img[0], $id );
+		$src_full = apply_filters( 'vpm_gallery_image_src_full', $img_full[0], $id );
 
 		// Fetch specific size
 		$img = wp_get_attachment_image_src( $id, $size );

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -42,7 +42,7 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 	);
 
 	// Filter the defaults
-	$defaults = apply_filter( 'vpm_gallery_defaults', $defaults );
+	$defaults = apply_filters( 'vpm_gallery_defaults', $defaults );
 
 	// Parse the args
 	$args = shortcode_atts( $defaults, $attr );
@@ -92,11 +92,11 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 
 		// Fetch full url, make cropped URL
 		$img_full = wp_get_attachment_image_src( $id, 'full' );
-		$src_full = apply_filter( 'vpm_gallery_image_src_full', $img[0], $id );
+		$src_full = apply_filters( 'vpm_gallery_image_src_full', $img[0], $id );
 
 		// Fetch specific size
 		$img = wp_get_attachment_image_src( $id, $size );
-		$src = apply_filter( 'vpm_gallery_image_src', $img[0], $id, $size );
+		$src = apply_filters( 'vpm_gallery_image_src', $img[0], $id, $size );
 
 		// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)
 		$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt></dl>' );

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -95,8 +95,8 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 		$src_full = apply_filters( 'vpm_gallery_image_src_full', $img_full[0], $id );
 
 		// Fetch specific size
-		$img = wp_get_attachment_image_src( $id, $size );
-		$src = apply_filters( 'vpm_gallery_image_src', $img[0], $id, $size );
+		$img = wp_get_attachment_image_src( $id, isset( $size ) ? $size : 'full' );
+		$src = apply_filters( 'vpm_gallery_image_src', $img_full[0], $id, $size );
 
 		// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)
 		$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt></dl>' );

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -95,7 +95,7 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 		$src_full = apply_filters( 'vpm_gallery_image_src_full', $img_full[0], $id );
 
 		// Fetch specific size
-		$img = wp_get_attachment_image_src( $id, isset( $size ) ? $size : 'full' );
+		$img = wp_get_attachment_image_src( $id, $size );
 		$src = apply_filters( 'vpm_gallery_image_src', $img_full[0], $id, $size );
 
 		// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -8,154 +8,116 @@ Author: Van Patten Media Inc.
 Author URI: https://www.vanpattenmedia.com/
 */
 
-class VpmFlexibleGallery {
 
-	function __construct() {
-		add_filter( 'media_view_settings', array( $this, 'vpm_set_default_gallery_thumbnail_size' ) );
-		add_filter( 'post_gallery', array( $this, 'vpm_custom_gallery_output' ), 10, 2 );
+add_filter( 'post_gallery', 'vpm_custom_gallery_output', 10, 2 );
 
-		add_filter( 'vpm_gallery_image_src', array( $this, 'vpm_override_gallery_image_src' ), 10, 2 );
+/**
+ * Custom gallery output for better image quality control
+ *
+ * @param  string   $output
+ * @param  array    $attr
+ * @param  int|null $instance
+ * @return string   $output
+ */
+function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
+	global $post;
+
+	// Set to active post_id if no instance present
+	if ( ! isset( $instance ) || is_null( $instance ) ) {
+		$instance = $post->ID;
 	}
 
-	/**
-	 * Assigns the thumbnail image size to be used for gallery thumbnails by default
-	 *
-	 * @param array $settings
-	 * @return array $settings
-	 */
-	function vpm_set_default_gallery_thumbnail_size( $settings ) {
-		$settings['galleryDefaults']['size']    = 'thumbnail';
-		$settings['galleryDefaults']['columns'] = 3;
+	// Extract the shortcode attributes
+	$defaults = array(
+		'order'      => 'ASC',
+		'orderby'    => 'menu_order ID',
+		'id'         => $instance,
+		'itemtag'    => 'dl',
+		'icontag'    => 'dt',
+		'captiontag' => 'dd',
+		'columns'    => 2,
+		'size'       => isset( $attr['size'] ) ? $attr['size'] : 'thumbnail', // defaults to thumbnail size
+		'include'    => '',
+		'exclude'    => '',
+	);
 
-		return $settings;
+	// Filter the defaults
+	$defaults = apply_filter( 'vpm_gallery_defaults', $defaults );
+
+	// Parse the args
+	$args = shortcode_atts( $defaults, $attr );
+
+	// TODO replace extract
+	extract( $args );
+
+	// Ensure the instance is an integer
+	$instance = intval( $instance );
+
+	// Fetch attachments
+	if ( ! empty( $include ) ) {
+		$include     = preg_replace( '/[^0-9,]+/', '', $include );
+		$attachments = array();
+
+		$raw_attachments = get_posts( array(
+			'include'        => $include,
+			'post_type'      => 'attachment',
+			'post_mime_type' => 'image',
+			'order'          => isset( $order ) ? $order : 'ASC',
+			'orderby'        => isset( $orderby ) ? $orderby : 'menu_order'
+		) );
+
+		// Grab attachment IDs
+		foreach( $raw_attachments as $key => $val ) {
+			$attachments[ $val->ID ] = $raw_attachments[$key];
+		}
 	}
 
-	/**
-	 * Custom gallery output for better image quality control
-	 *
-	 * @param  string   $output
-	 * @param  array    $attr
-	 * @param  int|null $instance
-	 * @return string   $output
-	 */
-	function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
-		global $post;
-
-		// Set to active post_id if no instance present
-		if ( ! isset( $instance ) || is_null( $instance ) ) {
-			$instance = $post->ID;
-		}
-
-		// Extract the shortcode attributes
-		extract( shortcode_atts( array(
-			'order'      => 'ASC',
-			'orderby'    => 'menu_order ID',
-			'id'         => $instance,
-			'itemtag'    => 'dl',
-			'icontag'    => 'dt',
-			'captiontag' => 'dd',
-			'columns'    => apply_filters( 'vpm_gallery_column_count', 2 ),
-			'size'       => isset( $attr['size'] ) ? $attr['size'] : 'thumbnail', // defaults to thumbnail size
-			'include'    => '',
-			'exclude'    => ''
-		), $attr) );
-
-		// Ensure the instance is an integer
-		$instance = intval( $instance );
-
-		// Fetch attachments
-		if ( ! empty( $include ) ) {
-			$include         = preg_replace( '/[^0-9,]+/', '', $include );
-			$attachments     = array();
-
-			$raw_attachments = get_posts( array(
-				'include'        => $include,
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image',
-				'order'          => isset( $order ) ? $order : 'ASC',
-				'orderby'        => isset( $orderby ) ? $orderby : 'menu_order'
-			) );
-
-			// Grab attachment IDs
-			foreach( $raw_attachments as $key => $val ) {
-				$attachments[ $val->ID ] = $raw_attachments[$key];
-			}
-		}
-
-		// Bail early if no attachments from fetch
-		if ( empty( $attachments ) ) {
-			return '';
-		}
-
-		// Define layout args
-		$selector   = "gallery-{$instance}"; // unique selector for CSS
-		$columns    = isset( $attr['columns'] ) ? intval( $attr['columns'] ) : 3; // default to 3 columns if not set
-		$item_width = $columns > 0 ? floor( 100 / $columns ) : 100;
-		$size_class = sanitize_html_class( isset( $attr['size'] ) ? $attr['size'] : 'thumbnail' ); // for CSS purposes
-
-		// Gallery output
-		$inner_html = '';
-
-		// Loop attachments
-		$i = 0;
-		foreach( $attachments as $id => $attachment ) {
-
-			// Fetch full url, make cropped URL
-			$data = apply_filters( 'vpm_gallery_image_src', array( $this, 'vpm_override_gallery_image_src' ), $id );
-
-			// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)
-			$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt></dl>' );
-			$gallery_img_html  = apply_filters( 'vpm_gallery_img_markup', '<a href="%1$s"><img width="%3$s" height="%4$s" src="%2$s" class="attachment-thumbnail size-thumbnail" /></a>' );
-
-			$img_html   = sprintf( $gallery_img_html, $data['full_size_url'], $data['cropped_url'], $data['w'], $data['h'] );
-			$item_html  = sprintf( $gallery_item_html, $img_html );
-
-			// Append gallery item html
-			$inner_html .= $item_html;
-
-			// Add clear break div after every second image via modulo operator
-			if ( $columns > 0 && ++$i % $columns == 0 ) {
-				$inner_html .= '<br style="clear: both" />';
-			}
-		}
-
-		// Wrap the output
-		$wrapper_html = '<div id="%1$s" class="gallery gallery-id-%2$s gallery-columns-%3$s gallery-size-%4$s">%5$s</div>';
-		$output = sprintf( $wrapper_html, $selector, $instance, $columns, $size_class, $inner_html );
-
-		return $output;
+	// Bail early if no attachments from fetch
+	if ( empty( $attachments ) ) {
+		return '';
 	}
 
-	/**
-	 * Allows an image URL/ID to be overriden
-	 *
-	 * @param int 		$id
-	 * @return array 	$data
-	 */
-	function vpm_override_gallery_image_src( $id ) {
-		$img  = wp_get_attachment_image_src( $id, 'full' );
-		$args = array(
-			'q'    => 60,
-			'crop' => 'faces',
-			'fit'  => 'crop',
-			'w'    => 500,
-			'h'    => 500,
-		);
+	// Define layout args
+	$selector   = "gallery-{$instance}"; // unique selector for CSS
+	$columns    = isset( $attr['columns'] ) ? intval( $attr['columns'] ) : 3; // default to 3 columns if not set
+	$item_width = $columns > 0 ? floor( 100 / $columns ) : 100;
+	$size_class = sanitize_html_class( isset( $attr['size'] ) ? $attr['size'] : 'thumbnail' ); // for CSS purposes
 
-		$cropped = add_query_arg(
-			apply_filters( 'vpm_gallery_thumbnail_cropping', $args ),
-			$img[0]
-		);
+	// Gallery output
+	$inner_html = '';
 
-		$data = array(
-			'cropped_url'	=> $cropped,
-			'full_size_url' => $img[0],
-			'width' 		=> $args['w'],
-			'height' 		=> $args['h'],
-		);
+	// Loop attachments
+	$i = 0;
+	foreach( $attachments as $id => $attachment ) {
 
-		return $data;
+		// Fetch full url, make cropped URL
+		$img_full = wp_get_attachment_image_src( $id, 'full' );
+		$src_full = apply_filter( 'vpm_gallery_image_src_full', $img[0], $id );
+
+		// Fetch specific size
+		$img = wp_get_attachment_image_src( $id, $size );
+		$src = apply_filter( 'vpm_gallery_image_src', $img[0], $id, $size );
+
+		// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)
+		$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt></dl>' );
+		$gallery_img_html  = apply_filters( 'vpm_gallery_img_markup', '<a href="%1$s"><img src="%2$s" class="attachment-thumbnail"></a>' );
+
+		// Build the HTML
+		$img_html  = sprintf( $gallery_img_html, $src_full, $src );
+		$item_html = sprintf( $gallery_item_html, $img_html );
+
+		// Append gallery item html
+		$inner_html .= $item_html;
+
+		// Add clear break div after every second image via modulo operator
+		if ( $columns > 0 && ++$i % $columns == 0 ) {
+			$inner_html .= '<br style="clear: both" />';
+		}
 	}
+
+	// Wrap the output
+	$wrapper_html = '<div id="%1$s" class="gallery gallery-id-%2$s gallery-columns-%3$s gallery-size-%4$s">%5$s</div>';
+	$output = sprintf( $wrapper_html, $selector, $instance, $columns, $size_class, $inner_html );
+
+	return $output;
 }
-
-new VpmFlexibleGallery;


### PR DESCRIPTION
@mcfarlan here are the changes I've made:

1. Replaced the filter for column default with a combined filter for the default options — should make it easier to filter any aspect of the defaults
2. Removed most functions — we should only `add_filter` inside the actual themes this is used with
3. I normally advocate class-based plugins but it's super weird/hard to unhook a filter that's hooked inside a class. So since it's down to one method, procedural is more practical now
4. Reconstructed the way the image URLs are generated. This moves all our custom query string stuff out of the core plugin and into the sites implementing it, so it should work out of the box in most sites now as if it were a default WordPress gallery

Please review and test (I didn't test in the client site but I'm sure this broke things because I renamed filters and removed stuff). Let me know if my changes make sense!