### PR TITLE
added caption support to gallery item html

### DIFF
--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -103,7 +103,7 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 		// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)
 		$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt>%2$s</dl>' );
 		$gallery_img_html  = apply_filters( 'vpm_gallery_img_markup', '<a href="%1$s"><img src="%2$s" class="attachment-thumbnail"></a>' );
-		$gallery_img_caption_html = apply_filters( 'vpm_gallery_img_caption_markup', '<dd class="wp-caption-text gallery-caption">%1$s</dd>');
+		$gallery_img_caption_html = apply_filters( 'vpm_gallery_img_caption_markup', '<dd class="wp-caption-text gallery-caption">%1$s</dd>' );
 
 		// Build the HTML
 		$img_html  = sprintf( $gallery_img_html, $src_full, $src );

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -107,16 +107,14 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 
 		// Check if caption exists, otherwise caption empty html output
 		if ( ! $caption ) {
-
 			$gallery_caption_html = '';
-
 		}
 
 		// Build the HTML
 		$img_html     = sprintf( $gallery_img_html, $src_full, $src );
 		$caption_html = sprintf( $gallery_caption_html, $caption );
 		$item_html    = sprintf( $gallery_item_html, $img_html, $caption_html );
-		
+
 		// Append gallery item html
 		$inner_html .= $item_html;
 

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -101,15 +101,22 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 		$caption = $attachment->post_excerpt;
 
 		// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)
-		$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt>%2$s</dl>' );
-		$gallery_img_html  = apply_filters( 'vpm_gallery_img_markup', '<a href="%1$s"><img src="%2$s" class="attachment-thumbnail"></a>' );
-		$gallery_img_caption_html = apply_filters( 'vpm_gallery_img_caption_markup', '<dd class="wp-caption-text gallery-caption">%1$s</dd>' );
+		$gallery_item_html    = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt>%2$s</dl>' );
+		$gallery_img_html     = apply_filters( 'vpm_gallery_img_markup', '<a href="%1$s"><img src="%2$s" class="attachment-thumbnail"></a>' );
+		$gallery_caption_html = apply_filters( 'vpm_gallery_img_caption_markup', '<dd class="wp-caption-text gallery-caption">%1$s</dd>' );
+
+		// Check if caption exists, otherwise caption empty html output
+		if ( ! $caption ) {
+
+			$gallery_caption_html = '';
+
+		}
 
 		// Build the HTML
-		$img_html  = sprintf( $gallery_img_html, $src_full, $src );
-		$caption_html = sprintf( $gallery_img_caption_html, $caption );
-		$item_html = sprintf( $gallery_item_html, $img_html, $caption_html );
-
+		$img_html     = sprintf( $gallery_img_html, $src_full, $src );
+		$caption_html = sprintf( $gallery_caption_html, $caption );
+		$item_html    = sprintf( $gallery_item_html, $img_html, $caption_html );
+		
 		// Append gallery item html
 		$inner_html .= $item_html;
 

--- a/vpm-flexible-gallery.php
+++ b/vpm-flexible-gallery.php
@@ -97,13 +97,18 @@ function vpm_custom_gallery_output( $output, $attr, $instance = null ) {
 		$img = wp_get_attachment_image_src( $id, $size );
 		$src = apply_filters( 'vpm_gallery_image_src', $img_full[0], $id, $size );
 
+		// Fetch image caption
+		$caption = $attachment->post_excerpt;
+
 		// Output of image item; default WP structure (dl.gallery-item > dt.gallery-icon > a > img)
-		$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt></dl>' );
+		$gallery_item_html = apply_filters( 'vpm_gallery_item_markup', '<dl class="gallery-item"><dt class="gallery-icon">%1$s</dt>%2$s</dl>' );
 		$gallery_img_html  = apply_filters( 'vpm_gallery_img_markup', '<a href="%1$s"><img src="%2$s" class="attachment-thumbnail"></a>' );
+		$gallery_img_caption_html = apply_filters( 'vpm_gallery_img_caption_markup', '<dd class="wp-caption-text gallery-caption">%1$s</dd>');
 
 		// Build the HTML
 		$img_html  = sprintf( $gallery_img_html, $src_full, $src );
-		$item_html = sprintf( $gallery_item_html, $img_html );
+		$caption_html = sprintf( $gallery_img_caption_html, $caption );
+		$item_html = sprintf( $gallery_item_html, $img_html, $caption_html );
 
 		// Append gallery item html
 		$inner_html .= $item_html;


### PR DESCRIPTION
Added caption HTML support for individual image gallery items.

Before: 
<img width="969" alt="screen shot 2017-10-27 at 10 32 47 am" src="https://user-images.githubusercontent.com/32365230/32109315-5d88961e-bb02-11e7-83a4-69f99f051b9f.png">

After:
<img width="980" alt="screen shot 2017-10-27 at 10 33 05 am" src="https://user-images.githubusercontent.com/32365230/32109318-6230e6a8-bb02-11e7-8e9d-a53a5dc84e4a.png">

Caption HTML output: 
<img width="784" alt="screen shot 2017-10-27 at 10 34 56 am" src="https://user-images.githubusercontent.com/32365230/32109396-9ce064b8-bb02-11e7-9968-6c4528e237fb.png">

